### PR TITLE
add commit history

### DIFF
--- a/src/smith/mod.rs
+++ b/src/smith/mod.rs
@@ -74,6 +74,10 @@ pub trait Smith: FmtDebug + Send + Sync {
     /// This function will return an error if the package cannot be resolved.
     fn resolve(&self, package: &Package) -> ErrorStackResult<Self::Input, ResolveError>;
 
+    /// Get latest commits for a git repo,
+    ///
+    /// # Errors
+    /// This function will return an error if it cannot find the commits
     fn get_latest_commits(
         &self,
         old_sha: Option<git2::Oid>,

--- a/src/smith/mod.rs
+++ b/src/smith/mod.rs
@@ -74,6 +74,12 @@ pub trait Smith: FmtDebug + Send + Sync {
     /// This function will return an error if the package cannot be resolved.
     fn resolve(&self, package: &Package) -> ErrorStackResult<Self::Input, ResolveError>;
 
+    fn get_latest_commits(
+        &self,
+        old_sha: Option<git2::Oid>,
+        path: &Path,
+    ) -> ErrorStackResult<Vec<String>, LoadError>;
+
     /// Loads a package.
     /// This downloads and installs the package to the given directory.
     ///


### PR DESCRIPTION
Adds a fn to smith to get commit history, with or without a provided sha, if no sha is provided it grabs up to 5 of the latest commits. 

While I was developing I wasn't too sure where this function should go, so if you all think of a better spot im happy to move it over.

